### PR TITLE
Remove BOOTSTRAP usage from multicluster-devsecops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-BOOTSTRAP=1
-
 .PHONY: default
 default: help
 


### PR DESCRIPTION
It's unused anyways.
