### PR TITLE
Add super linter

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,0 +1,38 @@
+---
+name: Super linter
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    # Name the Job
+    name: Super linter
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter/slim@v4
+        env:
+          VALIDATE_ALL_CODEBASE: true
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # These are the validation we disable atm
+          VALIDATE_BASH: false
+          VALIDATE_JSCPD: false
+          VALIDATE_KUBERNETES_KUBEVAL: false
+          VALIDATE_YAML: false
+          # VALIDATE_ANSIBLE: false
+          # VALIDATE_DOCKERFILE_HADOLINT: false
+          # VALIDATE_MARKDOWN: false
+          # VALIDATE_NATURAL_LANGUAGE: false
+          # VALIDATE_TEKTON: false

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,10 @@ helmlint:
 	# no regional charts just yet: "$(wildcard charts/region/*)"
 	@for t in "$(wildcard charts/all/*)" "$(wildcard charts/hub/*)"; do helm lint $$t; if [ $$? != 0 ]; then exit 1; fi; done
 
+super-linter: ## Runs super linter locally
+	podman run -e RUN_LOCAL=true -e USE_FIND_ALGORITHM=true	\
+					-e VALIDATE_BASH=false \
+					-e VALIDATE_JSCPD=false \
+					-e VALIDATE_KUBERNETES_KUBEVAL=false \
+					-e VALIDATE_YAML=false \
+					-v $(PWD):/tmp/lint:rw,z docker.io/github/super-linter:slim-v4

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Start Here
 
 If you've followed a link to this repo, but are not really sure what it contains
-or how to use it, head over to http://hybrid-cloud-patterns.io/multicluster-devsecops/
+or how to use it, head over to [multicluster-devsecops](https://hybrid-cloud-patterns.io/multicluster-devsecops/)
 for additional context and installation instructions
 [Currently the above link is a WIP]
 
-# Products/projects used
+## Products/projects used
+
 * Red Hat OpenShift GitOps
 * Red Hat Advanced Cluster Management
 * Red Hat Advanced Cluster Security
@@ -13,4 +14,3 @@ for additional context and installation instructions
 * Red Hat Quay
 * Red Hat OpenShift Pipelines
 * Hashicorp Vault (Community)
-


### PR DESCRIPTION
We disable the following linters to begin with:

  VALIDATE_BASH: false
  VALIDATE_JSCPD: false
  VALIDATE_KUBERNETES_KUBEVAL: false
  VALIDATE_YAML: false

Kubeval is already covered by us and we cannot use this one because it
does not have all of our OCP-specific schemas. JSCP needs to be disabled
because our is not yaml for the most part but helm templates which are
not recognized. Same with the YAML validator.
We can debate if we reenable shell later. In any case we should to it
only after we merge the vault utils ansible port.

Our main goal is to always have gitleaks running to be notified if a
key/password gets pushed accidentally. We can see that it is indeed
running:

  2022-06-27 15:47:57 [INFO]   ---------------------------
  2022-06-27 15:47:57 [INFO]   File:[/github/workspace/clustergroup/templates/namespaces.yaml]
  2022-06-27 15:47:57 [INFO]    - File:[namespaces.yaml] was linted with [gitleaks] successfully
  2022-06-27 15:47:57 [INFO]      - Command output:
  ------
      ○
      │╲
      │ ○
      ○ ░
      ░    gitleaks
  3:47PMINF scan completed in 404.005µs
  3:47PMINF no leaks found
