### PR TITLE
Revert "Replicate the main argocd rbac policy for namespaced instances"

### DIFF
--- a/common/clustergroup/templates/argocd.yaml
+++ b/common/clustergroup/templates/argocd.yaml
@@ -68,10 +68,7 @@ spec:
         memory: 128Mi
   initialSSHKnownHosts: {}
   rbac:
-    policy: |
-      g, system:cluster-admins, role:admin
-      g, cluster-admins, role:admin
-    scopes: '[groups]'
+    defaultPolicy: role:admin
   repo:
     resources:
       limits:


### PR DESCRIPTION
This reverts commit 3ee9bb64127081520050e502e497e55056bfa41a.
We'll bring this in via proper common/ ways
