### PR TITLE
Switch to using global.localClusterDomain for StackRox clusterName

### DIFF
--- a/charts/hub/acs/secured/templates/securedcluster-stackrox-secured-cluster-services.yaml
+++ b/charts/hub/acs/secured/templates/securedcluster-stackrox-secured-cluster-services.yaml
@@ -6,7 +6,7 @@ metadata:
   name: stackrox-secured-cluster-services
   namespace: stackrox
 spec:
-  clusterName: {{ .Values.global.localClusterName }}
+  clusterName: {{ (split "." .Values.global.localClusterDomain)._1 }}
   auditLogs:
     collection: Auto
   admissionControl:

--- a/charts/hub/acs/secured/values.yaml
+++ b/charts/hub/acs/secured/values.yaml
@@ -1,2 +1,2 @@
 global:
-  localClusterName: acs-secured
+  localClusterDomain: apps.hub-cluster.blueprints.rhecoeng.com

--- a/common/acm/templates/policies/application-policies.yaml
+++ b/common/acm/templates/policies/application-policies.yaml
@@ -59,8 +59,6 @@ spec:
                         value: {{ $.Values.global.hubClusterDomain }}
                       - name: global.localClusterDomain
                         value: '{{ `{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain }}` }}'
-                      - name: global.localClusterName
-                        value: '{{ `{{ (lookup "cluster.open-cluster-management.io/v1alpha1" "ClusterClaim" "" "name").spec.value }}` }}'
                      {{- range .helmOverrides }}
                       - name: {{ .name }}
                         value: {{ .value | quote }}

--- a/common/clustergroup/templates/applications.yaml
+++ b/common/clustergroup/templates/applications.yaml
@@ -64,8 +64,6 @@ spec:
               value: {{ $.Values.global.hubClusterDomain }}
             - name: global.localClusterDomain
               value: {{ coalesce $.Values.global.localClusterDomain $.Values.global.hubClusterDomain }}
-            - name: global.localClusterName
-              value: {{ $.Values.global.localClusterName }}
             - name: global.repoURL
               value: {{ $.Values.global.repoURL }}
             - name: global.targetRevision
@@ -131,8 +129,6 @@ spec:
           value: {{ $.Values.global.hubClusterDomain }}
         - name: global.localClusterDomain
           value: {{ coalesce $.Values.global.localClusterDomain $.Values.global.hubClusterDomain }}
-        - name: global.localClusterName
-          value: {{ $.Values.global.localClusterName }}
         {{- range .overrides }}
         - name: {{ .name }}
           value: {{ .value | quote }}

--- a/common/clustergroup/templates/argocd.yaml
+++ b/common/clustergroup/templates/argocd.yaml
@@ -39,7 +39,6 @@ spec:
             --set global.pattern={{ .Values.global.pattern }}
             --set global.hubClusterDomain={{ .Values.global.hubClusterDomain }}
             --set global.localClusterDomain={{ coalesce .Values.global.localClusterDomain .Values.global.hubClusterDomain }}
-            --set global.localClusterName={{ .Values.global.localClusterName }}
             --post-renderer ./kustomize"]
   applicationSet:
     resources:

--- a/common/tests/acm-normal.expected.yaml
+++ b/common/tests/acm-normal.expected.yaml
@@ -136,8 +136,6 @@ spec:
                         value: hub.example.com
                       - name: global.localClusterDomain
                         value: '{{ (lookup "config.openshift.io/v1" "Ingress" "" "cluster").spec.domain }}'
-                      - name: global.localClusterName
-                        value: '{{ (lookup "cluster.open-cluster-management.io/v1alpha1" "ClusterClaim" "" "name").spec.value }}'
                       - name: clusterGroup.isHubCluster
                         value: "false"
                   destination:

--- a/common/tests/clustergroup-naked.expected.yaml
+++ b/common/tests/clustergroup-naked.expected.yaml
@@ -97,7 +97,6 @@ spec:
             --set global.pattern=common
             --set global.hubClusterDomain=
             --set global.localClusterDomain=
-            --set global.localClusterName=
             --post-renderer ./kustomize"]
   applicationSet:
     resources:

--- a/common/tests/clustergroup-normal.expected.yaml
+++ b/common/tests/clustergroup-normal.expected.yaml
@@ -471,8 +471,6 @@ spec:
           value: hub.example.com
         - name: global.localClusterDomain
           value: region.example.com
-        - name: global.localClusterName
-          value: 
   ignoreDifferences: [
   {
     "group": "internal.open-cluster-management.io",
@@ -522,8 +520,6 @@ spec:
           value: hub.example.com
         - name: global.localClusterDomain
           value: region.example.com
-        - name: global.localClusterName
-          value: 
   syncPolicy:
     automated: {}
     #  selfHeal: true
@@ -569,7 +565,6 @@ spec:
             --set global.pattern=mypattern
             --set global.hubClusterDomain=hub.example.com
             --set global.localClusterDomain=region.example.com
-            --set global.localClusterName=
             --post-renderer ./kustomize"]
   applicationSet:
     resources:

--- a/tests/hub-acs-secured-naked.expected.yaml
+++ b/tests/hub-acs-secured-naked.expected.yaml
@@ -8,7 +8,7 @@ metadata:
   name: stackrox-secured-cluster-services
   namespace: stackrox
 spec:
-  clusterName: acs-secured
+  clusterName: hub-cluster
   auditLogs:
     collection: Auto
   admissionControl:

--- a/tests/hub-acs-secured-normal.expected.yaml
+++ b/tests/hub-acs-secured-normal.expected.yaml
@@ -8,7 +8,7 @@ metadata:
   name: stackrox-secured-cluster-services
   namespace: stackrox
 spec:
-  clusterName: acs-secured
+  clusterName: example
   auditLogs:
     collection: Auto
   admissionControl:


### PR DESCRIPTION
Instead of adding a new localClusterName variable which is quite a bit
of work due to a number of reasons (it needs to be set via an ACM policy
too and there is no split support with strings until ACM 2.6, so it
becomes hard to extract it). Let's just use localClusterDomain and take
out the cluster domain from there.
