### PR TITLE
s/clustergroup/clusterGroup to align with other patterns

### DIFF
--- a/charts/hub/acs/central/templates/integration/policy-acs-integrations-token.yaml
+++ b/charts/hub/acs/central/templates/integration/policy-acs-integrations-token.yaml
@@ -59,9 +59,9 @@ metadata:
 spec:
   # This will go to all devel clusters
   clusterSelector:
-    # Using matchLabels because I need it in only one clustergroup
+    # Using matchLabels because I need it in only one clusterGroup
     matchLabels:
-      clustergroup: devel 
+      clusterGroup: devel
   clusterConditions:
     - status: 'True'
       type: ManagedClusterConditionAvailable

--- a/charts/hub/external-secrets/templates/policy-quayio-registry-secret.yaml
+++ b/charts/hub/external-secrets/templates/policy-quayio-registry-secret.yaml
@@ -68,9 +68,9 @@ metadata:
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
-    # Using matchExpression because I need it in more than one clustergroup
+    # Using matchExpression because I need it in more than one clusterGroup
     matchExpressions:
-      - key: clustergroup
+      - key: clusterGroup
         operator: In
         values:
           - devel

--- a/charts/hub/quay/templates/quayRegistry/policy-quay-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/policy-quay-pull-secret.yaml
@@ -70,9 +70,9 @@ metadata:
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
-    # Using matchExpression because I need it in more than one clustergroup
+    # Using matchExpression because I need it in more than one clusterGroup
     matchExpressions:
-      - key: clustergroup
+      - key: clusterGroup
         operator: In
         values:
           - devel

--- a/tests/hub-acs-central-naked.expected.yaml
+++ b/tests/hub-acs-central-naked.expected.yaml
@@ -235,9 +235,9 @@ metadata:
 spec:
   # This will go to all devel clusters
   clusterSelector:
-    # Using matchLabels because I need it in only one clustergroup
+    # Using matchLabels because I need it in only one clusterGroup
     matchLabels:
-      clustergroup: devel 
+      clusterGroup: devel
   clusterConditions:
     - status: 'True'
       type: ManagedClusterConditionAvailable

--- a/tests/hub-acs-central-normal.expected.yaml
+++ b/tests/hub-acs-central-normal.expected.yaml
@@ -235,9 +235,9 @@ metadata:
 spec:
   # This will go to all devel clusters
   clusterSelector:
-    # Using matchLabels because I need it in only one clustergroup
+    # Using matchLabels because I need it in only one clusterGroup
     matchLabels:
-      clustergroup: devel 
+      clusterGroup: devel
   clusterConditions:
     - status: 'True'
       type: ManagedClusterConditionAvailable

--- a/tests/hub-external-secrets-naked.expected.yaml
+++ b/tests/hub-external-secrets-naked.expected.yaml
@@ -131,9 +131,9 @@ metadata:
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
-    # Using matchExpression because I need it in more than one clustergroup
+    # Using matchExpression because I need it in more than one clusterGroup
     matchExpressions:
-      - key: clustergroup
+      - key: clusterGroup
         operator: In
         values:
           - devel

--- a/tests/hub-external-secrets-normal.expected.yaml
+++ b/tests/hub-external-secrets-normal.expected.yaml
@@ -131,9 +131,9 @@ metadata:
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
-    # Using matchExpression because I need it in more than one clustergroup
+    # Using matchExpression because I need it in more than one clusterGroup
     matchExpressions:
-      - key: clustergroup
+      - key: clusterGroup
         operator: In
         values:
           - devel

--- a/tests/hub-quay-naked.expected.yaml
+++ b/tests/hub-quay-naked.expected.yaml
@@ -334,9 +334,9 @@ metadata:
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
-    # Using matchExpression because I need it in more than one clustergroup
+    # Using matchExpression because I need it in more than one clusterGroup
     matchExpressions:
-      - key: clustergroup
+      - key: clusterGroup
         operator: In
         values:
           - devel

--- a/tests/hub-quay-normal.expected.yaml
+++ b/tests/hub-quay-normal.expected.yaml
@@ -334,9 +334,9 @@ metadata:
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
-    # Using matchExpression because I need it in more than one clustergroup
+    # Using matchExpression because I need it in more than one clusterGroup
     matchExpressions:
-      - key: clustergroup
+      - key: clusterGroup
         operator: In
         values:
           - devel

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -144,7 +144,7 @@ clusterGroup:
       value: "false"
     clusterSelector:
       matchLabels:
-        clustergroup: devel
+        clusterGroup: devel
       matchExpressions:
       - key: vendor
         operator: In
@@ -157,7 +157,7 @@ clusterGroup:
       value: "false"
     clusterSelector:
       matchLabels:
-        clustergroup: prod
+        clusterGroup: prod
       matchExpressions:
       - key: vendor
         operator: In

--- a/values-opphub.yaml
+++ b/values-opphub.yaml
@@ -118,7 +118,7 @@ clusterGroup:
       value: "false"
     clusterSelector:
       matchLabels:
-        clustergroup: devel
+        clusterGroup: devel
       matchExpressions:
       - key: vendor
         operator: In
@@ -131,7 +131,7 @@ clusterGroup:
       value: "false"
     clusterSelector:
       matchLabels:
-        clustergroup: secured
+        clusterGroup: secured
       matchExpressions:
       - key: vendor
         operator: In


### PR DESCRIPTION
All the other patterns use "clusterGroup" written in camel-case.
Let's make sure we all use the same otherwise things become
especially confusing for users.
