### PR TITLE
Move main.opp variable in global.opp

### DIFF
--- a/charts/hub/opp/Chart.yaml
+++ b/charts/hub/opp/Chart.yaml
@@ -13,7 +13,7 @@ version: 1.0.0
 # It is recommended to use it with quotes.
 appVersion: "1.0.0"
 
-#{{- if $.Values.main.opp }}
+#{{- if $.Values.global.opp }}
 #dependencies:
 #- name: acs
 #  version: "1.0"

--- a/values-global.yaml
+++ b/values-global.yaml
@@ -32,7 +32,7 @@ global:
       name: devel
       email: devel@myorg.com
     repo: example
+  opp: false
 
 main:
   clusterGroupName: hub
-  opp: false


### PR DESCRIPTION
The main section is to be used by the install chart only.
Variables with the main prefix are set by the Makefile. Let's keep this
distinction here as well and use global.opp.

Otherwise validation schema would break here
