### PR TITLE
Fixed access_key and secret_key

### DIFF
--- a/charts/hub/opp/templates/policy-ocm-observability.yaml
+++ b/charts/hub/opp/templates/policy-ocm-observability.yaml
@@ -30,16 +30,19 @@ spec:
             metadata:
               name: thanos-object-storage
               namespace: open-cluster-management-observability
+            type: Opaque
             stringData:
               thanos.yaml: |
                 type: s3
                 config:
                   bucket: '{{ `{{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-openshift-storage-obc-observability").spec.endpoint.bucketName }}` }}'
                   endpoint: '{{ `{{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-openshift-storage-obc-observability").spec.endpoint.bucketHost }}` }}'
-                  insecure: true
-                  access_key: '{{ `{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID }}` }}'
-                  secret_key: '{{ `{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY }}` }}'
-              type: Opaque
+                  insecure: false
+                  access_key: '{{ `{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID | base64dec }}` }}'
+                  secret_key: '{{ `{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY | base64dec }}` }}'
+                  http_config:
+                    tls_config:
+                      insecure_skip_verify: true
         - complianceType: musthave
           objectDefinition:
             apiVersion: observability.open-cluster-management.io/v1beta2

--- a/tests/hub-opp-industrial-edge-factory.expected.yaml
+++ b/tests/hub-opp-industrial-edge-factory.expected.yaml
@@ -134,16 +134,19 @@ spec:
             metadata:
               name: thanos-object-storage
               namespace: open-cluster-management-observability
+            type: Opaque
             stringData:
               thanos.yaml: |
                 type: s3
                 config:
                   bucket: '{{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-openshift-storage-obc-observability").spec.endpoint.bucketName }}'
                   endpoint: '{{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-openshift-storage-obc-observability").spec.endpoint.bucketHost }}'
-                  insecure: true
-                  access_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID }}'
-                  secret_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY }}'
-              type: Opaque
+                  insecure: false
+                  access_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID | base64dec }}'
+                  secret_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY | base64dec }}'
+                  http_config:
+                    tls_config:
+                      insecure_skip_verify: true
         - complianceType: musthave
           objectDefinition:
             apiVersion: observability.open-cluster-management.io/v1beta2

--- a/tests/hub-opp-industrial-edge-hub.expected.yaml
+++ b/tests/hub-opp-industrial-edge-hub.expected.yaml
@@ -134,16 +134,19 @@ spec:
             metadata:
               name: thanos-object-storage
               namespace: open-cluster-management-observability
+            type: Opaque
             stringData:
               thanos.yaml: |
                 type: s3
                 config:
                   bucket: '{{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-openshift-storage-obc-observability").spec.endpoint.bucketName }}'
                   endpoint: '{{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-openshift-storage-obc-observability").spec.endpoint.bucketHost }}'
-                  insecure: true
-                  access_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID }}'
-                  secret_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY }}'
-              type: Opaque
+                  insecure: false
+                  access_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID | base64dec }}'
+                  secret_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY | base64dec }}'
+                  http_config:
+                    tls_config:
+                      insecure_skip_verify: true
         - complianceType: musthave
           objectDefinition:
             apiVersion: observability.open-cluster-management.io/v1beta2

--- a/tests/hub-opp-medical-diagnosis-hub.expected.yaml
+++ b/tests/hub-opp-medical-diagnosis-hub.expected.yaml
@@ -134,16 +134,19 @@ spec:
             metadata:
               name: thanos-object-storage
               namespace: open-cluster-management-observability
+            type: Opaque
             stringData:
               thanos.yaml: |
                 type: s3
                 config:
                   bucket: '{{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-openshift-storage-obc-observability").spec.endpoint.bucketName }}'
                   endpoint: '{{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-openshift-storage-obc-observability").spec.endpoint.bucketHost }}'
-                  insecure: true
-                  access_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID }}'
-                  secret_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY }}'
-              type: Opaque
+                  insecure: false
+                  access_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID | base64dec }}'
+                  secret_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY | base64dec }}'
+                  http_config:
+                    tls_config:
+                      insecure_skip_verify: true
         - complianceType: musthave
           objectDefinition:
             apiVersion: observability.open-cluster-management.io/v1beta2

--- a/tests/hub-opp-naked.expected.yaml
+++ b/tests/hub-opp-naked.expected.yaml
@@ -134,16 +134,19 @@ spec:
             metadata:
               name: thanos-object-storage
               namespace: open-cluster-management-observability
+            type: Opaque
             stringData:
               thanos.yaml: |
                 type: s3
                 config:
                   bucket: '{{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-openshift-storage-obc-observability").spec.endpoint.bucketName }}'
                   endpoint: '{{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-openshift-storage-obc-observability").spec.endpoint.bucketHost }}'
-                  insecure: true
-                  access_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID }}'
-                  secret_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY }}'
-              type: Opaque
+                  insecure: false
+                  access_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID | base64dec }}'
+                  secret_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY | base64dec }}'
+                  http_config:
+                    tls_config:
+                      insecure_skip_verify: true
         - complianceType: musthave
           objectDefinition:
             apiVersion: observability.open-cluster-management.io/v1beta2

--- a/tests/hub-opp-normal.expected.yaml
+++ b/tests/hub-opp-normal.expected.yaml
@@ -134,16 +134,19 @@ spec:
             metadata:
               name: thanos-object-storage
               namespace: open-cluster-management-observability
+            type: Opaque
             stringData:
               thanos.yaml: |
                 type: s3
                 config:
                   bucket: '{{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-openshift-storage-obc-observability").spec.endpoint.bucketName }}'
                   endpoint: '{{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-openshift-storage-obc-observability").spec.endpoint.bucketHost }}'
-                  insecure: true
-                  access_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID }}'
-                  secret_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY }}'
-              type: Opaque
+                  insecure: false
+                  access_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID | base64dec }}'
+                  secret_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY | base64dec }}'
+                  http_config:
+                    tls_config:
+                      insecure_skip_verify: true
         - complianceType: musthave
           objectDefinition:
             apiVersion: observability.open-cluster-management.io/v1beta2


### PR DESCRIPTION
The issue is that in the "thanos-object-storage" secret, in the the "thanos.yaml" key the "access_key" and "secret_key" value were encoded, while they need to be decoded in order to be used Also, fixed the issue with TLS, as with "insecure: ture" thanos tries to connect via http, while to disable the tls verification we need to edit the "http_config" key