### PR TITLE
Update pattern for OCP 4.12

### DIFF
--- a/values-AWS-4.12.yaml
+++ b/values-AWS-4.12.yaml
@@ -1,0 +1,2 @@
+cloudProvider:
+  storageClass: gp2-csi

--- a/values-AWS.yaml
+++ b/values-AWS.yaml
@@ -1,2 +1,2 @@
 cloudProvider:
-  storageClass: gp2
+  storageClass: gp2-csi

--- a/values-AWS.yaml
+++ b/values-AWS.yaml
@@ -1,2 +1,2 @@
 cloudProvider:
-  storageClass: gp2-csi
+  storageClass: gp2

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -24,25 +24,26 @@ clusterGroup:
 #         only used if global.options.useCSV: true in values-global.yaml
 
   subscriptions:
+# If specific channels are required then uncomment channel line and add the name of the channel
     acm:
       name: advanced-cluster-management
       namespace: open-cluster-management
-#      channel: release-2.6
+#      channel: 
 
     acs:
       name: rhacs-operator  #packageName
       namespace: openshift-operators # operator namespace
-      channel: rhacs-3.71
+#      channel: 
 
     odf:
       name: odf-operator
       namespace: openshift-storage
-#      channel: stable-4.10
+#      channel: 
 
     quay:
       name: quay-operator
       namespace: openshift-operators
-#      channel: stable-3.7
+#      channel: 
 
 # The following section is used by
 # OpenShift GitOps (ArgoCD)

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -27,7 +27,7 @@ clusterGroup:
     acm:
       name: advanced-cluster-management
       namespace: open-cluster-management
-      channel: release-2.6
+#      channel: release-2.6
 
     acs:
       name: rhacs-operator  #packageName
@@ -37,12 +37,12 @@ clusterGroup:
     odf:
       name: odf-operator
       namespace: openshift-storage
-      channel: stable-4.10
+#      channel: stable-4.10
 
     quay:
       name: quay-operator
       namespace: openshift-operators
-      channel: stable-3.7
+#      channel: stable-3.7
 
 # The following section is used by
 # OpenShift GitOps (ArgoCD)


### PR DESCRIPTION
The main updates were to:
1. remove specific subscription channels and allow default selection
2. Add a values-AWS-4.12..yaml file that had  new storage class `gp2-csi` - this will be come the default later. 