### PR TITLE
Mbp461

### DIFF
--- a/values-development.yaml
+++ b/values-development.yaml
@@ -45,17 +45,14 @@ clusterGroup:
     rhacs-operator:
       name: rhacs-operator  #packageName
       namespace: openshift-operators # operator namespace
-      channel: rhacs-3.71
 
     openshift-pipelines:
       name: openshift-pipelines-operator-rh
       namespace: openshift-operators
-      channel: pipelines-1.7
 
     quay-bridge-operator:
       name: quay-bridge-operator
       namespace: openshift-operators
-      channel: stable-3.7
 
   projects:
     - secured

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -28,22 +28,18 @@ clusterGroup:
     acm:
       name: advanced-cluster-management
       namespace: open-cluster-management
-#      channel: 
 
     acs:
       name: rhacs-operator  #packageName
       namespace: openshift-operators # operator namespace
-#      channel: 
 
     odf:
       name: odf-operator
       namespace: openshift-storage
-#      channel: 
 
     quay:
       name: quay-operator
       namespace: openshift-operators
-#      channel: 
 
 # The following section is used by
 # OpenShift GitOps (ArgoCD)

--- a/values-opphub.yaml
+++ b/values-opphub.yaml
@@ -28,22 +28,18 @@ clusterGroup:
     advanced-cluster-management:
       name: advanced-cluster-management
       namespace: open-cluster-management
-      channel: release-2.5
 
     rhacs-operator:
       name: rhacs-operator  #packageName
       namespace: openshift-operators # operator namespace
-      channel: rhacs-3.68
 
     odf-operator:
       name: odf-operator
       namespace: openshift-storage
-      channel: stable-4.10
 
     quay-operator:
       name: quay-operator
       namespace: openshift-operators
-      channel: stable-3.7
 
 # The following section is used by
 # OpenShift GitOps (ArgoCD)

--- a/values-production.yaml
+++ b/values-production.yaml
@@ -18,12 +18,10 @@ clusterGroup:
     rhacs-operator:
       name: rhacs-operator  #packageName
       namespace: openshift-operators # operator namespace
-      channel: rhacs-3.71
 
     quay-bridge-operator:
       name: quay-bridge-operator
       namespace: openshift-operators
-      channel: stable-3.7
 
   projects:
     - app


### PR DESCRIPTION
this pr resolves deployment issues in `clusterGroup: devel`.

openshift-pipelines v1.7 is not available in OpenShift 4.12 catalogSource and was preventing the rest of the operators from deploying.  Removed the `channel` parameter to align with direction other patterns are taking to use default channel. 