### PR TITLE
Add Compliance Operator to pattern and enable in hub cluster

### DIFF
--- a/charts/hub/compliance-operator/Chart.yaml
+++ b/charts/hub/compliance-operator/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: openshift-compliance-operator
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"

--- a/charts/hub/compliance-operator/templates/scansettingbinding-ocp4-high-node.yaml
+++ b/charts/hub/compliance-operator/templates/scansettingbinding-ocp4-high-node.yaml
@@ -1,0 +1,13 @@
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: ocp4-high-node
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: ocp4-high-node
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default

--- a/charts/hub/compliance-operator/templates/scansettingbinding-ocp4-high.yaml
+++ b/charts/hub/compliance-operator/templates/scansettingbinding-ocp4-high.yaml
@@ -1,0 +1,13 @@
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: ocp4-high
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: ocp4-high
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default

--- a/charts/hub/compliance-operator/templates/scansettingbinding-rhcos4-nist-high.yaml
+++ b/charts/hub/compliance-operator/templates/scansettingbinding-rhcos4-nist-high.yaml
@@ -1,0 +1,13 @@
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: rhcos4-nist-high
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: rhcos4-high
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default

--- a/charts/hub/compliance-operator/values.yaml
+++ b/charts/hub/compliance-operator/values.yaml
@@ -1,0 +1,3 @@
+# Default values for container-security-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.

--- a/tests/hub-compliance-operator-industrial-edge-factory.expected.yaml
+++ b/tests/hub-compliance-operator-industrial-edge-factory.expected.yaml
@@ -1,0 +1,45 @@
+---
+# Source: openshift-compliance-operator/templates/scansettingbinding-ocp4-high-node.yaml
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: ocp4-high-node
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: ocp4-high-node
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default
+---
+# Source: openshift-compliance-operator/templates/scansettingbinding-ocp4-high.yaml
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: ocp4-high
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: ocp4-high
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default
+---
+# Source: openshift-compliance-operator/templates/scansettingbinding-rhcos4-nist-high.yaml
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: rhcos4-nist-high
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: rhcos4-high
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default

--- a/tests/hub-compliance-operator-industrial-edge-hub.expected.yaml
+++ b/tests/hub-compliance-operator-industrial-edge-hub.expected.yaml
@@ -1,0 +1,45 @@
+---
+# Source: openshift-compliance-operator/templates/scansettingbinding-ocp4-high-node.yaml
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: ocp4-high-node
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: ocp4-high-node
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default
+---
+# Source: openshift-compliance-operator/templates/scansettingbinding-ocp4-high.yaml
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: ocp4-high
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: ocp4-high
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default
+---
+# Source: openshift-compliance-operator/templates/scansettingbinding-rhcos4-nist-high.yaml
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: rhcos4-nist-high
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: rhcos4-high
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default

--- a/tests/hub-compliance-operator-medical-diagnosis-hub.expected.yaml
+++ b/tests/hub-compliance-operator-medical-diagnosis-hub.expected.yaml
@@ -1,0 +1,45 @@
+---
+# Source: openshift-compliance-operator/templates/scansettingbinding-ocp4-high-node.yaml
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: ocp4-high-node
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: ocp4-high-node
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default
+---
+# Source: openshift-compliance-operator/templates/scansettingbinding-ocp4-high.yaml
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: ocp4-high
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: ocp4-high
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default
+---
+# Source: openshift-compliance-operator/templates/scansettingbinding-rhcos4-nist-high.yaml
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: rhcos4-nist-high
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: rhcos4-high
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default

--- a/tests/hub-compliance-operator-naked.expected.yaml
+++ b/tests/hub-compliance-operator-naked.expected.yaml
@@ -1,0 +1,45 @@
+---
+# Source: openshift-compliance-operator/templates/scansettingbinding-ocp4-high-node.yaml
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: ocp4-high-node
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: ocp4-high-node
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default
+---
+# Source: openshift-compliance-operator/templates/scansettingbinding-ocp4-high.yaml
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: ocp4-high
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: ocp4-high
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default
+---
+# Source: openshift-compliance-operator/templates/scansettingbinding-rhcos4-nist-high.yaml
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: rhcos4-nist-high
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: rhcos4-high
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default

--- a/tests/hub-compliance-operator-normal.expected.yaml
+++ b/tests/hub-compliance-operator-normal.expected.yaml
@@ -1,0 +1,45 @@
+---
+# Source: openshift-compliance-operator/templates/scansettingbinding-ocp4-high-node.yaml
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: ocp4-high-node
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: ocp4-high-node
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default
+---
+# Source: openshift-compliance-operator/templates/scansettingbinding-ocp4-high.yaml
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: ocp4-high
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: ocp4-high
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default
+---
+# Source: openshift-compliance-operator/templates/scansettingbinding-rhcos4-nist-high.yaml
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: rhcos4-nist-high
+  namespace: openshift-compliance
+profiles:
+- apiGroup: compliance.openshift.io/v1alpha1
+  kind: Profile
+  name: rhcos4-high
+settingsRef:
+  apiGroup: compliance.openshift.io/v1alpha1
+  kind: ScanSetting
+  name: default

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -9,6 +9,7 @@ clusterGroup:
   - open-cluster-management
   - vault
   - golang-external-secrets
+  - openshift-compliance
   - rhacs-operator
   - stackrox
   - policies
@@ -41,6 +42,10 @@ clusterGroup:
       name: quay-operator
       namespace: openshift-operators
 
+    openshift-compliance:
+      name: compliance-operator
+      namespace: openshift-compliance
+
 # The following section is used by
 # OpenShift GitOps (ArgoCD)
 # Projects are just ArgoCD groupings that can be filtered on.
@@ -60,6 +65,12 @@ clusterGroup:
         kind: ManagedClusterInfo
         jsonPointers:
           - /spec/loggingCA
+
+    openshift-compliance:
+      name: compliance-operator
+      namespace: openshift-compliance
+      project: hub
+      path: charts/hub/compliance-operator
 
     acs-central:
       name: acs-central


### PR DESCRIPTION
Changelog:

- Add namespace, subscription, and operator chart location for Compliance Operator to values-hub.yaml
- Create chart location for compliance-operator under charts/hub/compliance-operator
- Added default chart stubs
- Added templates for ScanSettingBindings for ocp4-high, ocp4-node-high, and rhcos4-high NIST content
- Added additional generated unit tests from pattern.sh output
- Tested on 4.11 and 4.12