### PR TITLE
Drop ansible/playbooks/on-hub-get-regional-ca.yml imperative job

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -127,12 +127,12 @@ clusterGroup:
     # imagePullPolicy is set to always: imperative.imagePullPolicy
     # For additional overrides that apply to the jobs, please refer to
     # https://hybrid-cloud-patterns.io/imperative-actions/#additional-job-customizations
-    jobs:
-    - name: regional-ca
+    #jobs:
+    #- name: regional-ca
       # ansible playbook to be run
-      playbook: ansible/playbooks/on-hub-get-regional-ca.yml
+      # playbook: common/ansible/playbooks/hello-world/hello-world.yaml
       # per playbook timeout in seconds
-      timeout: 234
+      # timeout: 234
       # verbosity: "-v"
 
 # This section is used by ACM


### PR DESCRIPTION
It does not exist and causes just broken pods to show up in argo.
Let's comment it out and in the comment we leave a small hello-world
imperative example for reference.

Closes: #70
