### PR TITLE
Made the clusterGroup.imperative map empty by default

### DIFF
--- a/values-AWS-4.12.yaml
+++ b/values-AWS-4.12.yaml
@@ -1,0 +1,3 @@
+cloudProvider:
+  storageClass: gp3-csi
+  provisioner: ebs.csi.aws.com

--- a/values-AWS-4.12.yaml
+++ b/values-AWS-4.12.yaml
@@ -1,3 +1,0 @@
-cloudProvider:
-  storageClass: gp3-csi
-  provisioner: ebs.csi.aws.com

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -120,7 +120,7 @@ clusterGroup:
       project: hub
       path: charts/hub/cli-tools
 
-  imperative:
+  imperative: {}
     # NOTE: We *must* use lists and not hashes. As hashes lose ordering once parsed by helm
     # The default schedule is every 10 minutes: imperative.schedule
     # Total timeout of all jobs is 1h: imperative.activeDeadlineSeconds


### PR DESCRIPTION
I started to look into the Pattern in 4.12 and the ```multicluster-devsecops-hub``` application in the default OpenShift GitOps Project was not working properly. Looking at the value file, I saw that the key holds hashes and after putting the opening-closing brace everything started to work again as intended.

I assume that if one wants to edit or add some values he needs to add them to the ```values-*-hub.yaml```, right?