### PR TITLE
Added key to skip TLS verification

### DIFF
--- a/charts/hub/opp/templates/policy-ocm-observability.yaml
+++ b/charts/hub/opp/templates/policy-ocm-observability.yaml
@@ -41,6 +41,7 @@ spec:
                   access_key: '{{ `{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID | base64dec }}` }}'
                   secret_key: '{{ `{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY | base64dec }}` }}'
                   http_config:
+                    insecure_skip_verify: true
                     tls_config:
                       insecure_skip_verify: true
         - complianceType: musthave

--- a/tests/hub-opp-industrial-edge-factory.expected.yaml
+++ b/tests/hub-opp-industrial-edge-factory.expected.yaml
@@ -145,6 +145,7 @@ spec:
                   access_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID | base64dec }}'
                   secret_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY | base64dec }}'
                   http_config:
+                    insecure_skip_verify: true
                     tls_config:
                       insecure_skip_verify: true
         - complianceType: musthave

--- a/tests/hub-opp-industrial-edge-hub.expected.yaml
+++ b/tests/hub-opp-industrial-edge-hub.expected.yaml
@@ -145,6 +145,7 @@ spec:
                   access_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID | base64dec }}'
                   secret_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY | base64dec }}'
                   http_config:
+                    insecure_skip_verify: true
                     tls_config:
                       insecure_skip_verify: true
         - complianceType: musthave

--- a/tests/hub-opp-medical-diagnosis-hub.expected.yaml
+++ b/tests/hub-opp-medical-diagnosis-hub.expected.yaml
@@ -145,6 +145,7 @@ spec:
                   access_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID | base64dec }}'
                   secret_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY | base64dec }}'
                   http_config:
+                    insecure_skip_verify: true
                     tls_config:
                       insecure_skip_verify: true
         - complianceType: musthave

--- a/tests/hub-opp-naked.expected.yaml
+++ b/tests/hub-opp-naked.expected.yaml
@@ -145,6 +145,7 @@ spec:
                   access_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID | base64dec }}'
                   secret_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY | base64dec }}'
                   http_config:
+                    insecure_skip_verify: true
                     tls_config:
                       insecure_skip_verify: true
         - complianceType: musthave

--- a/tests/hub-opp-normal.expected.yaml
+++ b/tests/hub-opp-normal.expected.yaml
@@ -145,6 +145,7 @@ spec:
                   access_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_ACCESS_KEY_ID | base64dec }}'
                   secret_key: '{{ (lookup "v1" "Secret" "openshift-storage" "noobaa-admin").data.AWS_SECRET_ACCESS_KEY | base64dec }}'
                   http_config:
+                    insecure_skip_verify: true
                     tls_config:
                       insecure_skip_verify: true
         - complianceType: musthave


### PR DESCRIPTION
Today I'm on fire :)
I noticed that Thanos kept logging that the certificate was signed by an unknown authority:
```
level=info ts=2023-04-19T12:30:45.075003434Z caller=intrumentation.go:81 msg="changing probe status" status=not-healthy reason="bucket store initial sync: sync block: BaseFetcher: iter bucket: Get \"https://s3.openshift-storage.svc/obc-observability-bucket-c829c765-34b4-4f27-a8e6-2f6e1257624a/?location=\": x509: certificate signed by unknown authority"
```
Which was strange since it should have been fixed with the [previous PR](https://github.com/hybrid-cloud-patterns/multicluster-devsecops/pull/65), so I checked and the image that runs Thanos uses version 0.29.0:
```
[root@test-5588478b5b-5ljql /]# thanos --version
thanos, version 0.29.0 (branch: non-git, revision: non-git)
[...]
```
And looking at the [docs for the 0.29 version](https://thanos.io/v0.29/thanos/storage.md/#s3), it looks like that they've added another ```insecure_skip_verify``` key under ```http_config```. Setting it to ```true``` makes everything working again:
```
level=info ts=2023-04-19T13:04:18.522450867Z caller=http.go:73 service=http/server component=store msg="listening for requests and metrics" address=0.0.0.0:10902
level=info ts=2023-04-19T13:04:18.522838715Z caller=tls_config.go:195 service=http/server component=store msg="TLS is disabled." http2=false
level=info ts=2023-04-19T13:04:18.523771411Z caller=fetcher.go:475 component=block.BaseFetcher msg="successfully synchronized block metadata" duration=1.348163ms duration_ms=1 cached=0 returned=0 partial=0
level=info ts=2023-04-19T13:04:18.52391605Z caller=store.go:373 msg="bucket store ready" init_duration=1.494879ms
level=info ts=2023-04-19T13:04:18.524020278Z caller=intrumentation.go:56 msg="changing probe status" status=ready
level=info ts=2023-04-19T13:04:18.524066081Z caller=grpc.go:131 service=gRPC/server component=store msg="listening for serving gRPC" address=0.0.0.0:10901
level=info ts=2023-04-19T13:04:18.524174013Z caller=fetcher.go:475 component=block.BaseFetcher msg="successfully synchronized block metadata" duration=238.198µs duration_ms=0 cached=0 returned=0 partial=0
```