### PR TITLE
Ci fixes

### DIFF
--- a/charts/hub/external-secrets/templates/eso-reports-htpasswd.yaml
+++ b/charts/hub/external-secrets/templates/eso-reports-htpasswd.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Values.global.cicd.namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:

--- a/charts/hub/external-secrets/templates/eso-reports-htpasswd.yaml
+++ b/charts/hub/external-secrets/templates/eso-reports-htpasswd.yaml
@@ -3,6 +3,8 @@ kind: ExternalSecret
 metadata:
   name: reports-nginx-externalsecret
   namespace: {{ .Values.global.cicd.namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   refreshInterval: 15s
   secretStoreRef:

--- a/charts/hub/external-secrets/templates/git-secret.yaml
+++ b/charts/hub/external-secrets/templates/git-secret.yaml
@@ -1,10 +1,11 @@
 ---
----
 apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: git-secret
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   refreshInterval: 15s
   secretStoreRef:

--- a/charts/hub/external-secrets/templates/git-secret.yaml
+++ b/charts/hub/external-secrets/templates/git-secret.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:

--- a/charts/hub/external-secrets/templates/image-registry-credentials.yaml
+++ b/charts/hub/external-secrets/templates/image-registry-credentials.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:

--- a/charts/hub/external-secrets/templates/image-registry-credentials.yaml
+++ b/charts/hub/external-secrets/templates/image-registry-credentials.yaml
@@ -5,6 +5,8 @@ metadata:
   # This is the external image registry (e.g. quay.io/docker)
   name: image-registry-credentials
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   refreshInterval: 15s
   secretStoreRef:

--- a/charts/hub/external-secrets/templates/policy-git-secret.yaml
+++ b/charts/hub/external-secrets/templates/policy-git-secret.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
+    argocd.argoproj.io/sync-options: PruneLast=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce
@@ -49,6 +49,8 @@ kind: PlacementBinding
 metadata:
   name: git-secret-placement-binding
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 placementRef:
   name: git-secret-placement
   kind: PlacementRule
@@ -64,6 +66,8 @@ kind: PlacementRule
 metadata:
   name: git-secret-placement
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:

--- a/charts/hub/external-secrets/templates/policy-git-secret.yaml
+++ b/charts/hub/external-secrets/templates/policy-git-secret.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce

--- a/charts/hub/external-secrets/templates/policy-quayio-registry-secret.yaml
+++ b/charts/hub/external-secrets/templates/policy-quayio-registry-secret.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
     argocd.argoproj.io/sync-wave: "7"
 spec:
   remediationAction: enforce

--- a/charts/hub/external-secrets/templates/policy-quayio-registry-secret.yaml
+++ b/charts/hub/external-secrets/templates/policy-quayio-registry-secret.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
+    argocd.argoproj.io/sync-options: PruneLast=true
     argocd.argoproj.io/sync-wave: "7"
 spec:
   remediationAction: enforce
@@ -49,6 +49,8 @@ kind: PlacementBinding
 metadata:
   name: quayio-secret-placement-binding
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 placementRef:
   name: quayio-secret-placement
   kind: PlacementRule
@@ -64,6 +66,8 @@ kind: PlacementRule
 metadata:
   name: quayio-secret-placement
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:

--- a/charts/hub/external-secrets/templates/policy-reports-nginx-secret.yaml
+++ b/charts/hub/external-secrets/templates/policy-reports-nginx-secret.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Values.global.cicd.namespace }}
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce

--- a/charts/hub/external-secrets/templates/policy-reports-nginx-secret.yaml
+++ b/charts/hub/external-secrets/templates/policy-reports-nginx-secret.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Values.global.cicd.namespace }}
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
+    argocd.argoproj.io/sync-options: PruneLast=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce
@@ -47,6 +47,8 @@ kind: PlacementBinding
 metadata:
   name: reports-nginx-secret-placement-binding
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 placementRef:
   name: reports-nginx-secret-placement
   kind: PlacementRule
@@ -62,6 +64,8 @@ kind: PlacementRule
 metadata:
   name: reports-nginx-secret-placement
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:

--- a/charts/region/pipelines/templates/app-pipeline/rbac/pipeline-sa.yaml
+++ b/charts/region/pipelines/templates/app-pipeline/rbac/pipeline-sa.yaml
@@ -8,7 +8,6 @@ metadata:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
     argocd.argoproj.io/syncOptions: ServerSideApply=true
 secrets:
-  - name: quay-api-token
   - name: acs-api-token
   - name: git-secret
 {{- if eq .Values.global.imageregistry.type "quay" }}

--- a/charts/region/pipelines/templates/chains/tekton-chains-configmap.yaml
+++ b/charts/region/pipelines/templates/chains/tekton-chains-configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: chains-config
   namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 data:
   artifacts.oci.storage: 'oci'
   artifacts.taskrun.format: tekton

--- a/tests/hub-external-secrets-industrial-edge-factory.expected.yaml
+++ b/tests/hub-external-secrets-industrial-edge-factory.expected.yaml
@@ -32,6 +32,9 @@ kind: ExternalSecret
 metadata:
   name: reports-nginx-externalsecret
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:
@@ -47,12 +50,14 @@ spec:
       key: secret/data/hub/devsecops
 ---
 # Source: external-secrets/templates/git-secret.yaml
----
 apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: git-secret
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:
@@ -77,6 +82,9 @@ metadata:
   # This is the external image registry (e.g. quay.io/docker)
   name: image-registry-credentials
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:

--- a/tests/hub-external-secrets-industrial-edge-hub.expected.yaml
+++ b/tests/hub-external-secrets-industrial-edge-hub.expected.yaml
@@ -32,6 +32,9 @@ kind: ExternalSecret
 metadata:
   name: reports-nginx-externalsecret
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:
@@ -47,12 +50,14 @@ spec:
       key: secret/data/hub/devsecops
 ---
 # Source: external-secrets/templates/git-secret.yaml
----
 apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: git-secret
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:
@@ -77,6 +82,9 @@ metadata:
   # This is the external image registry (e.g. quay.io/docker)
   name: image-registry-credentials
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:
@@ -95,6 +103,8 @@ kind: PlacementBinding
 metadata:
   name: git-secret-placement-binding
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 placementRef:
   name: git-secret-placement
   kind: PlacementRule
@@ -110,6 +120,8 @@ kind: PlacementBinding
 metadata:
   name: quayio-secret-placement-binding
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 placementRef:
   name: quayio-secret-placement
   kind: PlacementRule
@@ -125,6 +137,8 @@ kind: PlacementBinding
 metadata:
   name: reports-nginx-secret-placement-binding
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 placementRef:
   name: reports-nginx-secret-placement
   kind: PlacementRule
@@ -141,6 +155,8 @@ kind: PlacementRule
 metadata:
   name: git-secret-placement
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
@@ -162,6 +178,8 @@ kind: PlacementRule
 metadata:
   name: quayio-secret-placement
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
@@ -182,6 +200,8 @@ kind: PlacementRule
 metadata:
   name: reports-nginx-secret-placement
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
@@ -203,7 +223,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
+    argocd.argoproj.io/sync-options: PruneLast=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce
@@ -246,7 +266,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
+    argocd.argoproj.io/sync-options: PruneLast=true
     argocd.argoproj.io/sync-wave: "7"
 spec:
   remediationAction: enforce
@@ -289,7 +309,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
+    argocd.argoproj.io/sync-options: PruneLast=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce

--- a/tests/hub-external-secrets-industrial-edge-hub.expected.yaml
+++ b/tests/hub-external-secrets-industrial-edge-hub.expected.yaml
@@ -203,7 +203,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce
@@ -246,7 +246,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
     argocd.argoproj.io/sync-wave: "7"
 spec:
   remediationAction: enforce
@@ -289,7 +289,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce

--- a/tests/hub-external-secrets-medical-diagnosis-hub.expected.yaml
+++ b/tests/hub-external-secrets-medical-diagnosis-hub.expected.yaml
@@ -32,6 +32,9 @@ kind: ExternalSecret
 metadata:
   name: reports-nginx-externalsecret
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:
@@ -47,12 +50,14 @@ spec:
       key: secret/data/hub/devsecops
 ---
 # Source: external-secrets/templates/git-secret.yaml
----
 apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: git-secret
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:
@@ -77,6 +82,9 @@ metadata:
   # This is the external image registry (e.g. quay.io/docker)
   name: image-registry-credentials
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:
@@ -95,6 +103,8 @@ kind: PlacementBinding
 metadata:
   name: git-secret-placement-binding
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 placementRef:
   name: git-secret-placement
   kind: PlacementRule
@@ -110,6 +120,8 @@ kind: PlacementBinding
 metadata:
   name: quayio-secret-placement-binding
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 placementRef:
   name: quayio-secret-placement
   kind: PlacementRule
@@ -125,6 +137,8 @@ kind: PlacementBinding
 metadata:
   name: reports-nginx-secret-placement-binding
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 placementRef:
   name: reports-nginx-secret-placement
   kind: PlacementRule
@@ -141,6 +155,8 @@ kind: PlacementRule
 metadata:
   name: git-secret-placement
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
@@ -162,6 +178,8 @@ kind: PlacementRule
 metadata:
   name: quayio-secret-placement
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
@@ -182,6 +200,8 @@ kind: PlacementRule
 metadata:
   name: reports-nginx-secret-placement
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
@@ -203,7 +223,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
+    argocd.argoproj.io/sync-options: PruneLast=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce
@@ -246,7 +266,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
+    argocd.argoproj.io/sync-options: PruneLast=true
     argocd.argoproj.io/sync-wave: "7"
 spec:
   remediationAction: enforce
@@ -289,7 +309,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
+    argocd.argoproj.io/sync-options: PruneLast=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce

--- a/tests/hub-external-secrets-medical-diagnosis-hub.expected.yaml
+++ b/tests/hub-external-secrets-medical-diagnosis-hub.expected.yaml
@@ -203,7 +203,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce
@@ -246,7 +246,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
     argocd.argoproj.io/sync-wave: "7"
 spec:
   remediationAction: enforce
@@ -289,7 +289,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce

--- a/tests/hub-external-secrets-naked.expected.yaml
+++ b/tests/hub-external-secrets-naked.expected.yaml
@@ -32,6 +32,9 @@ kind: ExternalSecret
 metadata:
   name: reports-nginx-externalsecret
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:
@@ -47,12 +50,14 @@ spec:
       key: secret/data/hub/devsecops
 ---
 # Source: external-secrets/templates/git-secret.yaml
----
 apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: git-secret
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:
@@ -77,6 +82,9 @@ metadata:
   # This is the external image registry (e.g. quay.io/docker)
   name: image-registry-credentials
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:
@@ -95,6 +103,8 @@ kind: PlacementBinding
 metadata:
   name: git-secret-placement-binding
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 placementRef:
   name: git-secret-placement
   kind: PlacementRule
@@ -110,6 +120,8 @@ kind: PlacementBinding
 metadata:
   name: quayio-secret-placement-binding
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 placementRef:
   name: quayio-secret-placement
   kind: PlacementRule
@@ -125,6 +137,8 @@ kind: PlacementBinding
 metadata:
   name: reports-nginx-secret-placement-binding
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 placementRef:
   name: reports-nginx-secret-placement
   kind: PlacementRule
@@ -141,6 +155,8 @@ kind: PlacementRule
 metadata:
   name: git-secret-placement
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
@@ -162,6 +178,8 @@ kind: PlacementRule
 metadata:
   name: quayio-secret-placement
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
@@ -182,6 +200,8 @@ kind: PlacementRule
 metadata:
   name: reports-nginx-secret-placement
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
@@ -203,7 +223,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
+    argocd.argoproj.io/sync-options: PruneLast=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce
@@ -246,7 +266,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
+    argocd.argoproj.io/sync-options: PruneLast=true
     argocd.argoproj.io/sync-wave: "7"
 spec:
   remediationAction: enforce
@@ -289,7 +309,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
+    argocd.argoproj.io/sync-options: PruneLast=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce

--- a/tests/hub-external-secrets-naked.expected.yaml
+++ b/tests/hub-external-secrets-naked.expected.yaml
@@ -203,7 +203,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce
@@ -246,7 +246,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
     argocd.argoproj.io/sync-wave: "7"
 spec:
   remediationAction: enforce
@@ -289,7 +289,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce

--- a/tests/hub-external-secrets-normal.expected.yaml
+++ b/tests/hub-external-secrets-normal.expected.yaml
@@ -32,6 +32,9 @@ kind: ExternalSecret
 metadata:
   name: reports-nginx-externalsecret
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:
@@ -47,12 +50,14 @@ spec:
       key: secret/data/hub/devsecops
 ---
 # Source: external-secrets/templates/git-secret.yaml
----
 apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: git-secret
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:
@@ -77,6 +82,9 @@ metadata:
   # This is the external image registry (e.g. quay.io/docker)
   name: image-registry-credentials
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true, PruneLast=true
 spec:
   refreshInterval: 15s
   secretStoreRef:
@@ -95,6 +103,8 @@ kind: PlacementBinding
 metadata:
   name: git-secret-placement-binding
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 placementRef:
   name: git-secret-placement
   kind: PlacementRule
@@ -110,6 +120,8 @@ kind: PlacementBinding
 metadata:
   name: quayio-secret-placement-binding
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 placementRef:
   name: quayio-secret-placement
   kind: PlacementRule
@@ -125,6 +137,8 @@ kind: PlacementBinding
 metadata:
   name: reports-nginx-secret-placement-binding
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 placementRef:
   name: reports-nginx-secret-placement
   kind: PlacementRule
@@ -141,6 +155,8 @@ kind: PlacementRule
 metadata:
   name: git-secret-placement
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
@@ -162,6 +178,8 @@ kind: PlacementRule
 metadata:
   name: quayio-secret-placement
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
@@ -182,6 +200,8 @@ kind: PlacementRule
 metadata:
   name: reports-nginx-secret-placement
   namespace: devsecops-ci
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
@@ -203,7 +223,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
+    argocd.argoproj.io/sync-options: PruneLast=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce
@@ -246,7 +266,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
+    argocd.argoproj.io/sync-options: PruneLast=true
     argocd.argoproj.io/sync-wave: "7"
 spec:
   remediationAction: enforce
@@ -289,7 +309,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
+    argocd.argoproj.io/sync-options: PruneLast=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce

--- a/tests/hub-external-secrets-normal.expected.yaml
+++ b/tests/hub-external-secrets-normal.expected.yaml
@@ -203,7 +203,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce
@@ -246,7 +246,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
     argocd.argoproj.io/sync-wave: "7"
 spec:
   remediationAction: enforce
@@ -289,7 +289,7 @@ metadata:
   namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: PruneLast=true, ServerSideApply=true
     argocd.argoproj.io/sync-wave: "15"
 spec:
   remediationAction: enforce

--- a/tests/region-pipelines-industrial-edge-factory.expected.yaml
+++ b/tests/region-pipelines-industrial-edge-factory.expected.yaml
@@ -10,7 +10,6 @@ metadata:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
     argocd.argoproj.io/syncOptions: ServerSideApply=true
 secrets:
-  - name: quay-api-token
   - name: acs-api-token
   - name: git-secret
   - name: quay-pull-secret
@@ -70,6 +69,8 @@ kind: ConfigMap
 metadata:
   name: chains-config
   namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 data:
   artifacts.oci.storage: 'oci'
   artifacts.taskrun.format: tekton

--- a/tests/region-pipelines-industrial-edge-hub.expected.yaml
+++ b/tests/region-pipelines-industrial-edge-hub.expected.yaml
@@ -10,7 +10,6 @@ metadata:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
     argocd.argoproj.io/syncOptions: ServerSideApply=true
 secrets:
-  - name: quay-api-token
   - name: acs-api-token
   - name: git-secret
   - name: quay-pull-secret
@@ -70,6 +69,8 @@ kind: ConfigMap
 metadata:
   name: chains-config
   namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 data:
   artifacts.oci.storage: 'oci'
   artifacts.taskrun.format: tekton

--- a/tests/region-pipelines-medical-diagnosis-hub.expected.yaml
+++ b/tests/region-pipelines-medical-diagnosis-hub.expected.yaml
@@ -10,7 +10,6 @@ metadata:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
     argocd.argoproj.io/syncOptions: ServerSideApply=true
 secrets:
-  - name: quay-api-token
   - name: acs-api-token
   - name: git-secret
   - name: quay-pull-secret
@@ -70,6 +69,8 @@ kind: ConfigMap
 metadata:
   name: chains-config
   namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 data:
   artifacts.oci.storage: 'oci'
   artifacts.taskrun.format: tekton

--- a/tests/region-pipelines-naked.expected.yaml
+++ b/tests/region-pipelines-naked.expected.yaml
@@ -10,7 +10,6 @@ metadata:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
     argocd.argoproj.io/syncOptions: ServerSideApply=true
 secrets:
-  - name: quay-api-token
   - name: acs-api-token
   - name: git-secret
   - name: quay-pull-secret
@@ -70,6 +69,8 @@ kind: ConfigMap
 metadata:
   name: chains-config
   namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 data:
   artifacts.oci.storage: 'oci'
   artifacts.taskrun.format: tekton

--- a/tests/region-pipelines-normal.expected.yaml
+++ b/tests/region-pipelines-normal.expected.yaml
@@ -10,7 +10,6 @@ metadata:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
     argocd.argoproj.io/syncOptions: ServerSideApply=true
 secrets:
-  - name: quay-api-token
   - name: acs-api-token
   - name: git-secret
   - name: quay-pull-secret
@@ -70,6 +69,8 @@ kind: ConfigMap
 metadata:
   name: chains-config
   namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-options: PruneLast=true
 data:
   artifacts.oci.storage: 'oci'
   artifacts.taskrun.format: tekton


### PR DESCRIPTION
This PR fixes the issues related to CI:
- out-of-sync external-secrets | Applied a combination of sync-waves and sync-options to ensure that the resources (external-secrets and policies) are pruned appropriately.
- removed a secret from the pipeline-sa manifest so that when the pipeline is run there is no need to comment it out of the serviceaccount.
- updated sync-option on the cosign configmap to prevent the out-of-sync status 