### PR TITLE
Added the default "Admin" entry for RHACS

### DIFF
--- a/charts/hub/acs/central/templates/job-create-auth-provider.yaml
+++ b/charts/hub/acs/central/templates/job-create-auth-provider.yaml
@@ -29,7 +29,7 @@ spec:
               export DATA={\"name\":\"local-cluster\"}
               curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
               AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
-              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data '{"roleName":"Admin","props":{"authProviderId":"${AUTH_PROVIDER_ID}","key":"name","value":"kube:admin"}}' ### Adding the Admin entry for the KubeAdmin user
+              echo "curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data '{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}' ### Adding the Admin entry for the KubeAdmin user" | bash
           imagePullPolicy: Always
           name: create-auth-provider
       dnsPolicy: ClusterFirst

--- a/charts/hub/acs/central/templates/job-create-auth-provider.yaml
+++ b/charts/hub/acs/central/templates/job-create-auth-provider.yaml
@@ -29,7 +29,9 @@ spec:
               export DATA={\"name\":\"local-cluster\"}
               curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
               AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
-              echo "curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data '{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}' ### Adding the Admin entry for the KubeAdmin user" | bash
+              JSON_PAYLOAD='{"roleName":"Admin","props":{"authProviderId":"$AUTH_PROVIDER_ID","key":"name","value":"kube:admin"}}'
+              echo $JSON_PAYLOAD
+              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data "$JSON_PAYLOAD" ### Adding the Admin entry for the KubeAdmin user
           imagePullPolicy: Always
           name: create-auth-provider
       dnsPolicy: ClusterFirst

--- a/charts/hub/acs/central/templates/job-create-auth-provider.yaml
+++ b/charts/hub/acs/central/templates/job-create-auth-provider.yaml
@@ -30,7 +30,6 @@ spec:
               curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
               AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
               JSON_PAYLOAD="{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}"
-              echo $JSON_PAYLOAD
               curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data "$JSON_PAYLOAD" ### Adding the Admin entry for the KubeAdmin user
           imagePullPolicy: Always
           name: create-auth-provider

--- a/charts/hub/acs/central/templates/job-create-auth-provider.yaml
+++ b/charts/hub/acs/central/templates/job-create-auth-provider.yaml
@@ -29,7 +29,6 @@ spec:
               export DATA={\"name\":\"local-cluster\"}
               curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
               AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
-              echo $AUTH_PROVIDER_ID
               echo "curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data '{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}' ### Adding the Admin entry for the KubeAdmin user" | bash
           imagePullPolicy: Always
           name: create-auth-provider

--- a/charts/hub/acs/central/templates/job-create-auth-provider.yaml
+++ b/charts/hub/acs/central/templates/job-create-auth-provider.yaml
@@ -30,7 +30,7 @@ spec:
               curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
               AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
               echo $AUTH_PROVIDER_ID
-              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups --data '{"roleName":"Admin","props":{"authProviderId":"$AUTH_PROVIDER_ID","key":"name","value":"kube:admin"}}' ### Adding the Admin entry for the KubeAdmin user
+              echo "curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data '{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}' ### Adding the Admin entry for the KubeAdmin user" | bash
           imagePullPolicy: Always
           name: create-auth-provider
       dnsPolicy: ClusterFirst

--- a/charts/hub/acs/central/templates/job-create-auth-provider.yaml
+++ b/charts/hub/acs/central/templates/job-create-auth-provider.yaml
@@ -29,6 +29,7 @@ spec:
               export DATA={\"name\":\"local-cluster\"}
               curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
               AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
+              echo $AUTH_PROVIDER_ID
               curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups --data '{"roleName":"Admin","props":{"authProviderId":"$AUTH_PROVIDER_ID","key":"name","value":"kube:admin"}}' ### Adding the Admin entry for the KubeAdmin user
           imagePullPolicy: Always
           name: create-auth-provider

--- a/charts/hub/acs/central/templates/job-create-auth-provider.yaml
+++ b/charts/hub/acs/central/templates/job-create-auth-provider.yaml
@@ -29,7 +29,7 @@ spec:
               export DATA={\"name\":\"local-cluster\"}
               curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
               AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
-              echo "curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data '{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}' ### Adding the Admin entry for the KubeAdmin user" | bash
+              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data '{"roleName":"Admin","props":{"authProviderId":"${AUTH_PROVIDER_ID}","key":"name","value":"kube:admin"}}' ### Adding the Admin entry for the KubeAdmin user
           imagePullPolicy: Always
           name: create-auth-provider
       dnsPolicy: ClusterFirst

--- a/charts/hub/acs/central/templates/job-create-auth-provider.yaml
+++ b/charts/hub/acs/central/templates/job-create-auth-provider.yaml
@@ -29,7 +29,7 @@ spec:
               export DATA={\"name\":\"local-cluster\"}
               curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
               AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
-              JSON_PAYLOAD='{"roleName":"Admin","props":{"authProviderId":"$AUTH_PROVIDER_ID","key":"name","value":"kube:admin"}}'
+              JSON_PAYLOAD="{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}"
               echo $JSON_PAYLOAD
               curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data "$JSON_PAYLOAD" ### Adding the Admin entry for the KubeAdmin user
           imagePullPolicy: Always

--- a/charts/hub/acs/central/templates/job-create-auth-provider.yaml
+++ b/charts/hub/acs/central/templates/job-create-auth-provider.yaml
@@ -27,7 +27,9 @@ spec:
               #!/usr/bin/env bash
               echo "Creating auth provider in RHACS"
               export DATA={\"name\":\"local-cluster\"}
-              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}'
+              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
+              AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
+              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups --data '{"roleName":"Admin","props":{"authProviderId":"$AUTH_PROVIDER_ID","key":"name","value":"kube:admin"}}' ### Adding the Admin entry for the KubeAdmin user
           imagePullPolicy: Always
           name: create-auth-provider
       dnsPolicy: ClusterFirst

--- a/tests/hub-acs-central-industrial-edge-factory.expected.yaml
+++ b/tests/hub-acs-central-industrial-edge-factory.expected.yaml
@@ -181,7 +181,9 @@ spec:
               #!/usr/bin/env bash
               echo "Creating auth provider in RHACS"
               export DATA={\"name\":\"local-cluster\"}
-              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}'
+              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
+              AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
+              echo "curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data '{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}' ### Adding the Admin entry for the KubeAdmin user" | bash
           imagePullPolicy: Always
           name: create-auth-provider
       dnsPolicy: ClusterFirst

--- a/tests/hub-acs-central-industrial-edge-factory.expected.yaml
+++ b/tests/hub-acs-central-industrial-edge-factory.expected.yaml
@@ -183,7 +183,8 @@ spec:
               export DATA={\"name\":\"local-cluster\"}
               curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
               AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
-              echo "curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data '{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}' ### Adding the Admin entry for the KubeAdmin user" | bash
+              JSON_PAYLOAD="{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}"
+              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data "$JSON_PAYLOAD" ### Adding the Admin entry for the KubeAdmin user
           imagePullPolicy: Always
           name: create-auth-provider
       dnsPolicy: ClusterFirst

--- a/tests/hub-acs-central-industrial-edge-hub.expected.yaml
+++ b/tests/hub-acs-central-industrial-edge-hub.expected.yaml
@@ -181,7 +181,9 @@ spec:
               #!/usr/bin/env bash
               echo "Creating auth provider in RHACS"
               export DATA={\"name\":\"local-cluster\"}
-              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}'
+              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
+              AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
+              echo "curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data '{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}' ### Adding the Admin entry for the KubeAdmin user" | bash
           imagePullPolicy: Always
           name: create-auth-provider
       dnsPolicy: ClusterFirst

--- a/tests/hub-acs-central-industrial-edge-hub.expected.yaml
+++ b/tests/hub-acs-central-industrial-edge-hub.expected.yaml
@@ -183,7 +183,8 @@ spec:
               export DATA={\"name\":\"local-cluster\"}
               curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
               AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
-              echo "curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data '{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}' ### Adding the Admin entry for the KubeAdmin user" | bash
+              JSON_PAYLOAD="{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}"
+              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data "$JSON_PAYLOAD" ### Adding the Admin entry for the KubeAdmin user
           imagePullPolicy: Always
           name: create-auth-provider
       dnsPolicy: ClusterFirst

--- a/tests/hub-acs-central-medical-diagnosis-hub.expected.yaml
+++ b/tests/hub-acs-central-medical-diagnosis-hub.expected.yaml
@@ -181,7 +181,9 @@ spec:
               #!/usr/bin/env bash
               echo "Creating auth provider in RHACS"
               export DATA={\"name\":\"local-cluster\"}
-              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}'
+              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
+              AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
+              echo "curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data '{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}' ### Adding the Admin entry for the KubeAdmin user" | bash
           imagePullPolicy: Always
           name: create-auth-provider
       dnsPolicy: ClusterFirst

--- a/tests/hub-acs-central-medical-diagnosis-hub.expected.yaml
+++ b/tests/hub-acs-central-medical-diagnosis-hub.expected.yaml
@@ -183,7 +183,8 @@ spec:
               export DATA={\"name\":\"local-cluster\"}
               curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
               AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
-              echo "curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data '{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}' ### Adding the Admin entry for the KubeAdmin user" | bash
+              JSON_PAYLOAD="{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}"
+              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data "$JSON_PAYLOAD" ### Adding the Admin entry for the KubeAdmin user
           imagePullPolicy: Always
           name: create-auth-provider
       dnsPolicy: ClusterFirst

--- a/tests/hub-acs-central-naked.expected.yaml
+++ b/tests/hub-acs-central-naked.expected.yaml
@@ -181,7 +181,9 @@ spec:
               #!/usr/bin/env bash
               echo "Creating auth provider in RHACS"
               export DATA={\"name\":\"local-cluster\"}
-              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}'
+              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
+              AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
+              echo "curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data '{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}' ### Adding the Admin entry for the KubeAdmin user" | bash
           imagePullPolicy: Always
           name: create-auth-provider
       dnsPolicy: ClusterFirst

--- a/tests/hub-acs-central-naked.expected.yaml
+++ b/tests/hub-acs-central-naked.expected.yaml
@@ -183,7 +183,8 @@ spec:
               export DATA={\"name\":\"local-cluster\"}
               curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
               AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
-              echo "curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data '{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}' ### Adding the Admin entry for the KubeAdmin user" | bash
+              JSON_PAYLOAD="{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}"
+              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data "$JSON_PAYLOAD" ### Adding the Admin entry for the KubeAdmin user
           imagePullPolicy: Always
           name: create-auth-provider
       dnsPolicy: ClusterFirst

--- a/tests/hub-acs-central-normal.expected.yaml
+++ b/tests/hub-acs-central-normal.expected.yaml
@@ -181,7 +181,9 @@ spec:
               #!/usr/bin/env bash
               echo "Creating auth provider in RHACS"
               export DATA={\"name\":\"local-cluster\"}
-              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}'
+              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
+              AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
+              echo "curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data '{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}' ### Adding the Admin entry for the KubeAdmin user" | bash
           imagePullPolicy: Always
           name: create-auth-provider
       dnsPolicy: ClusterFirst

--- a/tests/hub-acs-central-normal.expected.yaml
+++ b/tests/hub-acs-central-normal.expected.yaml
@@ -183,7 +183,8 @@ spec:
               export DATA={\"name\":\"local-cluster\"}
               curl -X POST -u "admin:$PASSWORD" -k https://central/v1/authProviders --data '{"name": "OpenShift OAuth", "type": "openshift", "enabled": true}' > /tmp/output.json
               AUTH_PROVIDER_ID=$(sed 's/,/\n/g' /tmp/output.json | grep -w id | awk -F\" '{ print $4 }') ### Since the image does not have the 'jq' command
-              echo "curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data '{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}' ### Adding the Admin entry for the KubeAdmin user" | bash
+              JSON_PAYLOAD="{\"roleName\":\"Admin\",\"props\":{\"authProviderId\":\"$AUTH_PROVIDER_ID\",\"key\":\"name\",\"value\":\"kube:admin\"}}"
+              curl -X POST -u "admin:$PASSWORD" -k https://central/v1/groups -s --data "$JSON_PAYLOAD" ### Adding the Admin entry for the KubeAdmin user
           imagePullPolicy: Always
           name: create-auth-provider
       dnsPolicy: ClusterFirst


### PR DESCRIPTION
With this change, I am adding the API call needed to add the ACS RBAC in order to make the OCP ```kubeadmin``` user an ACS Administrator. Prior to this change, an administrator needed to get the htpasswd secret and access the ACS console as the local ```admin``` user.