### PR TITLE
Moved "policy-quay-pull-secret" to the "devsecops-ci" ns

### DIFF
--- a/charts/hub/quay/templates/quayRegistry/policy-quay-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/policy-quay-pull-secret.yaml
@@ -2,7 +2,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: policy-quay-pull-secret
-  namespace: openshift-operators
+  namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
     argocd.argoproj.io/sync-options: SkipPrune

--- a/charts/hub/quay/templates/quayRegistry/policy-quay-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/policy-quay-pull-secret.yaml
@@ -25,6 +25,7 @@ spec:
             include:
               - default
               - openshift-operators
+              - devsecops-ci
           object-templates:
             - complianceType: mustonlyhave
               objectDefinition:
@@ -41,7 +42,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
   name: quay-pull-secret-placement-binding
-  namespace: openshift-operators
+  namespace: devsecops-ci
 placementRef:
   name: quay-pull-secret-placement
   kind: PlacementRule
@@ -56,7 +57,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: quay-pull-secret-placement
-  namespace: openshift-operators
+  namespace: devsecops-ci
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:

--- a/tests/hub-quay-industrial-edge-factory.expected.yaml
+++ b/tests/hub-quay-industrial-edge-factory.expected.yaml
@@ -326,7 +326,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
   name: quay-pull-secret-placement-binding
-  namespace: openshift-operators
+  namespace: devsecops-ci
 placementRef:
   name: quay-pull-secret-placement
   kind: PlacementRule
@@ -342,7 +342,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: quay-pull-secret-placement
-  namespace: openshift-operators
+  namespace: devsecops-ci
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
@@ -411,7 +411,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: policy-quay-pull-secret
-  namespace: openshift-operators
+  namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
     argocd.argoproj.io/sync-options: SkipPrune
@@ -434,6 +434,7 @@ spec:
             include:
               - default
               - openshift-operators
+              - devsecops-ci
           object-templates:
             - complianceType: mustonlyhave
               objectDefinition:

--- a/tests/hub-quay-industrial-edge-hub.expected.yaml
+++ b/tests/hub-quay-industrial-edge-hub.expected.yaml
@@ -326,7 +326,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
   name: quay-pull-secret-placement-binding
-  namespace: openshift-operators
+  namespace: devsecops-ci
 placementRef:
   name: quay-pull-secret-placement
   kind: PlacementRule
@@ -342,7 +342,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: quay-pull-secret-placement
-  namespace: openshift-operators
+  namespace: devsecops-ci
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
@@ -411,7 +411,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: policy-quay-pull-secret
-  namespace: openshift-operators
+  namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
     argocd.argoproj.io/sync-options: SkipPrune
@@ -434,6 +434,7 @@ spec:
             include:
               - default
               - openshift-operators
+              - devsecops-ci
           object-templates:
             - complianceType: mustonlyhave
               objectDefinition:

--- a/tests/hub-quay-medical-diagnosis-hub.expected.yaml
+++ b/tests/hub-quay-medical-diagnosis-hub.expected.yaml
@@ -326,7 +326,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
   name: quay-pull-secret-placement-binding
-  namespace: openshift-operators
+  namespace: devsecops-ci
 placementRef:
   name: quay-pull-secret-placement
   kind: PlacementRule
@@ -342,7 +342,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: quay-pull-secret-placement
-  namespace: openshift-operators
+  namespace: devsecops-ci
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
@@ -411,7 +411,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: policy-quay-pull-secret
-  namespace: openshift-operators
+  namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
     argocd.argoproj.io/sync-options: SkipPrune
@@ -434,6 +434,7 @@ spec:
             include:
               - default
               - openshift-operators
+              - devsecops-ci
           object-templates:
             - complianceType: mustonlyhave
               objectDefinition:

--- a/tests/hub-quay-naked.expected.yaml
+++ b/tests/hub-quay-naked.expected.yaml
@@ -326,7 +326,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
   name: quay-pull-secret-placement-binding
-  namespace: openshift-operators
+  namespace: devsecops-ci
 placementRef:
   name: quay-pull-secret-placement
   kind: PlacementRule
@@ -342,7 +342,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: quay-pull-secret-placement
-  namespace: openshift-operators
+  namespace: devsecops-ci
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
@@ -411,7 +411,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: policy-quay-pull-secret
-  namespace: openshift-operators
+  namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
     argocd.argoproj.io/sync-options: SkipPrune
@@ -434,6 +434,7 @@ spec:
             include:
               - default
               - openshift-operators
+              - devsecops-ci
           object-templates:
             - complianceType: mustonlyhave
               objectDefinition:

--- a/tests/hub-quay-normal.expected.yaml
+++ b/tests/hub-quay-normal.expected.yaml
@@ -326,7 +326,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
   name: quay-pull-secret-placement-binding
-  namespace: openshift-operators
+  namespace: devsecops-ci
 placementRef:
   name: quay-pull-secret-placement
   kind: PlacementRule
@@ -342,7 +342,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: quay-pull-secret-placement
-  namespace: openshift-operators
+  namespace: devsecops-ci
 spec:
   # This will go to both devel and secured clusters
   clusterSelector:
@@ -411,7 +411,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: policy-quay-pull-secret
-  namespace: openshift-operators
+  namespace: devsecops-ci
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
     argocd.argoproj.io/sync-options: SkipPrune
@@ -434,6 +434,7 @@ spec:
             include:
               - default
               - openshift-operators
+              - devsecops-ci
           object-templates:
             - complianceType: mustonlyhave
               objectDefinition:


### PR DESCRIPTION
I moved the policy and the related objects to the ```devsecops-ci``` namespace because the policy was issuing errors about the namespace argument passed to fromSecret being restricted to the namespace where the policy was, in our case ```openshift-operators```.

From the official [docs](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html-single/governance/index#fromsecret-func): "You must use the same namespace that is used for the policy when using the function in a hub cluster template."