### PR TITLE
updated collection method for acs secured clusters

### DIFF
--- a/charts/hub/acs/secured/templates/securedcluster-stackrox-secured-cluster-services.yaml
+++ b/charts/hub/acs/secured/templates/securedcluster-stackrox-secured-cluster-services.yaml
@@ -19,6 +19,6 @@ spec:
   centralEndpoint: central-stackrox.{{ .Values.global.hubClusterDomain }}:443
   perNode:
     collector:
-      collection: KernelModule
+      collection: EBPF
       imageFlavor: Regular
     taintToleration: TolerateTaints

--- a/tests/hub-acs-secured-industrial-edge-factory.expected.yaml
+++ b/tests/hub-acs-secured-industrial-edge-factory.expected.yaml
@@ -21,6 +21,6 @@ spec:
   centralEndpoint: central-stackrox.apps.hub.example.com:443
   perNode:
     collector:
-      collection: KernelModule
+      collection: EBPF
       imageFlavor: Regular
     taintToleration: TolerateTaints

--- a/tests/hub-acs-secured-industrial-edge-hub.expected.yaml
+++ b/tests/hub-acs-secured-industrial-edge-hub.expected.yaml
@@ -21,6 +21,6 @@ spec:
   centralEndpoint: central-stackrox.apps.hub.example.com:443
   perNode:
     collector:
-      collection: KernelModule
+      collection: EBPF
       imageFlavor: Regular
     taintToleration: TolerateTaints

--- a/tests/hub-acs-secured-medical-diagnosis-hub.expected.yaml
+++ b/tests/hub-acs-secured-medical-diagnosis-hub.expected.yaml
@@ -21,6 +21,6 @@ spec:
   centralEndpoint: central-stackrox.apps.hub.example.com:443
   perNode:
     collector:
-      collection: KernelModule
+      collection: EBPF
       imageFlavor: Regular
     taintToleration: TolerateTaints

--- a/tests/hub-acs-secured-naked.expected.yaml
+++ b/tests/hub-acs-secured-naked.expected.yaml
@@ -21,6 +21,6 @@ spec:
   centralEndpoint: central-stackrox.:443
   perNode:
     collector:
-      collection: KernelModule
+      collection: EBPF
       imageFlavor: Regular
     taintToleration: TolerateTaints

--- a/tests/hub-acs-secured-normal.expected.yaml
+++ b/tests/hub-acs-secured-normal.expected.yaml
@@ -21,6 +21,6 @@ spec:
   centralEndpoint: central-stackrox.apps.hub.example.com:443
   perNode:
     collector:
-      collection: KernelModule
+      collection: EBPF
       imageFlavor: Regular
     taintToleration: TolerateTaints


### PR DESCRIPTION
Deprecated collection method in acs secured clusters, changing default to EBPF as the other option is NONE or another BPF which is currently tech preview.