### PR TITLE
Wait for Quay Kubernetes Job Update

### DIFF
--- a/charts/hub/quay/templates/quayRegistry/cm-wait-for-quay-app-deploy.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-wait-for-quay-app-deploy.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # quaye abbrev. for Quay Enterprise
+  name: wait-for-quay-app-deploy
+  namespace: {{ .Values.quay.namespace }}
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/sync-wave: "6"
+data:
+  wait-on-quay-to-deploy.sh: |
+    echo -n "Waiting for the Quay Registry CR to be available ."
+    RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null;echo $?)
+
+    while [ $RC -ne 0 ]; do
+      sleep 2
+      echo -n "."
+      RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null;echo $?)
+    done
+    echo "done"

--- a/charts/hub/quay/templates/quayRegistry/cm-wait-for-quay-app-deploy.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-wait-for-quay-app-deploy.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   wait-on-quay-to-deploy.sh: |
     echo -n "Waiting for the Quay Registry CR to be available ."
-    RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null;echo $?)
+    RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null 2>&1;echo $?)
 
     while [ $RC -ne 0 ]; do
       sleep 2

--- a/charts/hub/quay/templates/quayRegistry/cm-wait-for-quay-app-deploy.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-wait-for-quay-app-deploy.yaml
@@ -10,11 +10,11 @@ metadata:
 data:
   wait-on-quay-to-deploy.sh: |
     echo -n "Waiting for the Quay Registry CR to be available ."
-    RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true 2>&1 /dev/null;echo $?)
+    RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null 2>&1;echo $?)
 
     while [ $RC -ne 0 ]; do
       sleep 2
       echo -n "."
-      RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null;echo $?)
+      RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null 2>&1;echo $?)
     done
     echo "done"

--- a/charts/hub/quay/templates/quayRegistry/cm-wait-for-quay-app-deploy.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-wait-for-quay-app-deploy.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   # quaye abbrev. for Quay Enterprise
-  name: wait-for-quay-app-deploy
+  name: wait-for-quay-app
   namespace: {{ .Values.quay.namespace }}
   annotations:
     argocd.argoproj.io/hook: Sync

--- a/charts/hub/quay/templates/quayRegistry/cm-wait-for-quay-app-deploy.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-wait-for-quay-app-deploy.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   wait-on-quay-to-deploy.sh: |
     echo -n "Waiting for the Quay Registry CR to be available ."
-    RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null 2>&1;echo $?)
+    RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true 2>&1 /dev/null;echo $?)
 
     while [ $RC -ne 0 ]; do
       sleep 2

--- a/charts/hub/quay/templates/quayRegistry/job-wait-on-quay-app-deploy.yaml
+++ b/charts/hub/quay/templates/quayRegistry/job-wait-on-quay-app-deploy.yaml
@@ -16,8 +16,17 @@ spec:
         - -c
         - |
           # wait for the operator QuayRegistry CR to be available
-          oc wait QuayRegistry quay-registry --for=condition=Available=true
+          /tmp/wait-on-quay-to-deploy.sh
         name: wait-for-quay-app
+        volumeMounts:
+          - mountPath: /tmp/wait-on-quay-to-deploy.sh
+            name: wait-for-quay-app
+            subPath: wait-on-quay-to-deploy.sh
+      volumes:
+        - name: wait-for-quay-app
+          configMap:
+            name: wait-for-quay-app
+            defaultMode: 0755
       dnsPolicy: ClusterFirst
       activeDeadlineSeconds: 900
       restartPolicy: Never

--- a/tests/hub-quay-industrial-edge-factory.expected.yaml
+++ b/tests/hub-quay-industrial-edge-factory.expected.yaml
@@ -197,6 +197,28 @@ data:
 
       echo "[INFO] Job finished"
 ---
+# Source: quay/templates/quayRegistry/cm-wait-for-quay-app-deploy.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # quaye abbrev. for Quay Enterprise
+  name: wait-for-quay-app
+  namespace: quay-enterprise
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/sync-wave: "6"
+data:
+  wait-on-quay-to-deploy.sh: |
+    echo -n "Waiting for the Quay Registry CR to be available ."
+    RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null 2>&1;echo $?)
+
+    while [ $RC -ne 0 ]; do
+      sleep 2
+      echo -n "."
+      RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null 2>&1;echo $?)
+    done
+    echo "done"
+---
 # Source: quay/templates/rbac/quay-admin-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -299,8 +321,17 @@ spec:
         - -c
         - |
           # wait for the operator QuayRegistry CR to be available
-          oc wait QuayRegistry quay-registry --for=condition=Available=true
+          /tmp/wait-on-quay-to-deploy.sh
         name: wait-for-quay-app
+        volumeMounts:
+          - mountPath: /tmp/wait-on-quay-to-deploy.sh
+            name: wait-for-quay-app
+            subPath: wait-on-quay-to-deploy.sh
+      volumes:
+        - name: wait-for-quay-app
+          configMap:
+            name: wait-for-quay-app
+            defaultMode: 0755
       dnsPolicy: ClusterFirst
       activeDeadlineSeconds: 900
       restartPolicy: Never

--- a/tests/hub-quay-industrial-edge-hub.expected.yaml
+++ b/tests/hub-quay-industrial-edge-hub.expected.yaml
@@ -197,6 +197,28 @@ data:
 
       echo "[INFO] Job finished"
 ---
+# Source: quay/templates/quayRegistry/cm-wait-for-quay-app-deploy.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # quaye abbrev. for Quay Enterprise
+  name: wait-for-quay-app
+  namespace: quay-enterprise
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/sync-wave: "6"
+data:
+  wait-on-quay-to-deploy.sh: |
+    echo -n "Waiting for the Quay Registry CR to be available ."
+    RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null 2>&1;echo $?)
+
+    while [ $RC -ne 0 ]; do
+      sleep 2
+      echo -n "."
+      RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null 2>&1;echo $?)
+    done
+    echo "done"
+---
 # Source: quay/templates/rbac/quay-admin-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -299,8 +321,17 @@ spec:
         - -c
         - |
           # wait for the operator QuayRegistry CR to be available
-          oc wait QuayRegistry quay-registry --for=condition=Available=true
+          /tmp/wait-on-quay-to-deploy.sh
         name: wait-for-quay-app
+        volumeMounts:
+          - mountPath: /tmp/wait-on-quay-to-deploy.sh
+            name: wait-for-quay-app
+            subPath: wait-on-quay-to-deploy.sh
+      volumes:
+        - name: wait-for-quay-app
+          configMap:
+            name: wait-for-quay-app
+            defaultMode: 0755
       dnsPolicy: ClusterFirst
       activeDeadlineSeconds: 900
       restartPolicy: Never

--- a/tests/hub-quay-medical-diagnosis-hub.expected.yaml
+++ b/tests/hub-quay-medical-diagnosis-hub.expected.yaml
@@ -197,6 +197,28 @@ data:
 
       echo "[INFO] Job finished"
 ---
+# Source: quay/templates/quayRegistry/cm-wait-for-quay-app-deploy.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # quaye abbrev. for Quay Enterprise
+  name: wait-for-quay-app
+  namespace: quay-enterprise
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/sync-wave: "6"
+data:
+  wait-on-quay-to-deploy.sh: |
+    echo -n "Waiting for the Quay Registry CR to be available ."
+    RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null 2>&1;echo $?)
+
+    while [ $RC -ne 0 ]; do
+      sleep 2
+      echo -n "."
+      RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null 2>&1;echo $?)
+    done
+    echo "done"
+---
 # Source: quay/templates/rbac/quay-admin-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -299,8 +321,17 @@ spec:
         - -c
         - |
           # wait for the operator QuayRegistry CR to be available
-          oc wait QuayRegistry quay-registry --for=condition=Available=true
+          /tmp/wait-on-quay-to-deploy.sh
         name: wait-for-quay-app
+        volumeMounts:
+          - mountPath: /tmp/wait-on-quay-to-deploy.sh
+            name: wait-for-quay-app
+            subPath: wait-on-quay-to-deploy.sh
+      volumes:
+        - name: wait-for-quay-app
+          configMap:
+            name: wait-for-quay-app
+            defaultMode: 0755
       dnsPolicy: ClusterFirst
       activeDeadlineSeconds: 900
       restartPolicy: Never

--- a/tests/hub-quay-naked.expected.yaml
+++ b/tests/hub-quay-naked.expected.yaml
@@ -197,6 +197,28 @@ data:
 
       echo "[INFO] Job finished"
 ---
+# Source: quay/templates/quayRegistry/cm-wait-for-quay-app-deploy.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # quaye abbrev. for Quay Enterprise
+  name: wait-for-quay-app
+  namespace: quay-enterprise
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/sync-wave: "6"
+data:
+  wait-on-quay-to-deploy.sh: |
+    echo -n "Waiting for the Quay Registry CR to be available ."
+    RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null 2>&1;echo $?)
+
+    while [ $RC -ne 0 ]; do
+      sleep 2
+      echo -n "."
+      RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null 2>&1;echo $?)
+    done
+    echo "done"
+---
 # Source: quay/templates/rbac/quay-admin-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -299,8 +321,17 @@ spec:
         - -c
         - |
           # wait for the operator QuayRegistry CR to be available
-          oc wait QuayRegistry quay-registry --for=condition=Available=true
+          /tmp/wait-on-quay-to-deploy.sh
         name: wait-for-quay-app
+        volumeMounts:
+          - mountPath: /tmp/wait-on-quay-to-deploy.sh
+            name: wait-for-quay-app
+            subPath: wait-on-quay-to-deploy.sh
+      volumes:
+        - name: wait-for-quay-app
+          configMap:
+            name: wait-for-quay-app
+            defaultMode: 0755
       dnsPolicy: ClusterFirst
       activeDeadlineSeconds: 900
       restartPolicy: Never

--- a/tests/hub-quay-normal.expected.yaml
+++ b/tests/hub-quay-normal.expected.yaml
@@ -197,6 +197,28 @@ data:
 
       echo "[INFO] Job finished"
 ---
+# Source: quay/templates/quayRegistry/cm-wait-for-quay-app-deploy.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # quaye abbrev. for Quay Enterprise
+  name: wait-for-quay-app
+  namespace: quay-enterprise
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/sync-wave: "6"
+data:
+  wait-on-quay-to-deploy.sh: |
+    echo -n "Waiting for the Quay Registry CR to be available ."
+    RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null 2>&1;echo $?)
+
+    while [ $RC -ne 0 ]; do
+      sleep 2
+      echo -n "."
+      RC=$(oc wait QuayRegistry quay-registry --for=condition=Available=true > /dev/null 2>&1;echo $?)
+    done
+    echo "done"
+---
 # Source: quay/templates/rbac/quay-admin-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -299,8 +321,17 @@ spec:
         - -c
         - |
           # wait for the operator QuayRegistry CR to be available
-          oc wait QuayRegistry quay-registry --for=condition=Available=true
+          /tmp/wait-on-quay-to-deploy.sh
         name: wait-for-quay-app
+        volumeMounts:
+          - mountPath: /tmp/wait-on-quay-to-deploy.sh
+            name: wait-for-quay-app
+            subPath: wait-on-quay-to-deploy.sh
+      volumes:
+        - name: wait-for-quay-app
+          configMap:
+            name: wait-for-quay-app
+            defaultMode: 0755
       dnsPolicy: ClusterFirst
       activeDeadlineSeconds: 900
       restartPolicy: Never


### PR DESCRIPTION
In DevSecOps we have a job that waits for the Quay resources to be available.
We have added a loop to wait for these resources to be available
to decrease the number of failed jobs.

- Added new config map with script to loop through
- Updated job to mount and execute new config map script.